### PR TITLE
Use kebab-case in test function names

### DIFF
--- a/t/00-basic.t
+++ b/t/00-basic.t
@@ -11,7 +11,7 @@ pass("Loaded Algorithm::Soundex");
 
 my Algorithm::Soundex $s .= new();
 
-isa_ok($s, Algorithm::Soundex);
+isa-ok($s, Algorithm::Soundex);
 
 my $soundex = $s.soundex("Robert");
 is($soundex, 'R163', 'soundex of Robert');


### PR DESCRIPTION
Test function names with underscores have been deprecated in favour of their
kebab-case variants.  The deprecated form will be removed in Rakudo 2015.09.
This change brings the test suite up to date with current Rakudo.
