### PR TITLE
Remove @*INC usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,4 @@
 
 ## Running Tests
 
-    prove -e perl6 -r t/
-
+    $ prove -e "perl6 -Ilib" -r t/

--- a/t/00-basic.t
+++ b/t/00-basic.t
@@ -1,9 +1,6 @@
 use v6;
 use Test;
 
-# because prove -l doesn't work for perl 6 modules
-BEGIN { unshift @*INC, './lib'; }
-
 plan 4;
 
 use Algorithm::Soundex;


### PR DESCRIPTION
... since `@*INC` has been removed from Rakudo.  This change fixes the issue
that `Algorithm::Soundex` can't be installed via `panda` at present.

The issue that `@*INC` was solving in this module was the fact that `prove -l`
doesn't include the `lib` directory when run for Perl 6 modules.  To try and
mitigate this problem I've updated the README to mention how to run `prove`
with Perl 6 and yet still find the module's `lib` directory.

If you wish for different solution to this problem, just let me know and I'll try to implement that.
