### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,15 +1,20 @@
 {
-    "perl"        : "6.*",
-    "name"        : "Algorithm::Soundex",
-    "version"     : "*",
-    "description" : "Soundex Algorithm in Perl 6",
-    "build-depends" : [ ],
-    "test-depends" : [
-        "Test"
-    ],
-    "depends" : [ ],
-    "provides" : {
-        "Algorithm::Soundex" : "lib/Algorithm/Soundex.pm"
-    },
-    "source-url"  : "git://github.com/leto/perl6-Algorithm-Soundex.git"
+  "name": "Algorithm::Soundex",
+  "source-url": "git://github.com/leto/perl6-Algorithm-Soundex.git",
+  "perl": "6.*",
+  "build-depends": [
+    
+  ],
+  "depends": [
+    
+  ],
+  "license": "Artistic-2.0",
+  "provides": {
+    "Algorithm::Soundex": "lib/Algorithm/Soundex.pm"
+  },
+  "test-depends": [
+    "Test"
+  ],
+  "version": "*",
+  "description": "Soundex Algorithm in Perl 6"
 }


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license